### PR TITLE
WIP: Elements: Move away from 8 decimals

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -472,6 +472,7 @@ std::string HelpMessage(HelpMessageMode mode)
     if (showDebug) {
         strUsage += HelpMessageOpt("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE));
         strUsage += HelpMessageOpt("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT));
+        strUsage += HelpMessageOpt("-rpcamountdecimals", strprintf(_("Use 8 decimals (BTC) or 0 decimals (satoshis) for rpc (default: %u)"), DEFAULT_8DECIMALS_GLOBAL));
     }
 
     return strUsage;
@@ -903,6 +904,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         nScriptCheckThreads = MAX_SCRIPTCHECK_THREADS;
 
     fServer = GetBoolArg("-server", false);
+    f8DecimalsGlobal = GetBoolArg("-rpcamountdecimals", DEFAULT_8DECIMALS_GLOBAL);
 
     // block pruning; get the amount of disk space (in MiB) to allot for block & undo files
     int64_t nSignedPruneTarget = GetArg("-prune", 0) * 1024 * 1024;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,6 +81,7 @@ size_t nCoinCacheUsage = 5000 * 300;
 uint64_t nPruneTarget = 0;
 int64_t nMaxTipAge = DEFAULT_MAX_TIP_AGE;
 bool fEnableReplacement = DEFAULT_ENABLE_REPLACEMENT;
+bool f8DecimalsGlobal = DEFAULT_8DECIMALS_GLOBAL;
 
 
 CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);

--- a/src/main.h
+++ b/src/main.h
@@ -133,7 +133,7 @@ static const bool DEFAULT_TESTSAFEMODE = false;
 /** Default for -mempoolreplacement */
 static const bool DEFAULT_ENABLE_REPLACEMENT = true;
 /** Default for -rpcamountdecimals */
-static const bool DEFAULT_8DECIMALS_GLOBAL = true;
+static const bool DEFAULT_8DECIMALS_GLOBAL = false;
 /** Default for using fee filter */
 static const bool DEFAULT_FEEFILTER = true;
 

--- a/src/main.h
+++ b/src/main.h
@@ -132,6 +132,8 @@ static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 static const bool DEFAULT_TESTSAFEMODE = false;
 /** Default for -mempoolreplacement */
 static const bool DEFAULT_ENABLE_REPLACEMENT = true;
+/** Default for -rpcamountdecimals */
+static const bool DEFAULT_8DECIMALS_GLOBAL = true;
 /** Default for using fee filter */
 static const bool DEFAULT_FEEFILTER = true;
 
@@ -176,6 +178,7 @@ extern CAmount maxTxFee;
 /** If the tip is older than this (in seconds), the node is considered to be in initial block download. */
 extern int64_t nMaxTipAge;
 extern bool fEnableReplacement;
+extern bool f8DecimalsGlobal;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -7,6 +7,7 @@
 
 #include "base58.h"
 #include "init.h"
+#include "main.h" // For f8DecimalsGlobal
 #include "random.h"
 #include "sync.h"
 #include "ui_interface.h"
@@ -147,12 +148,12 @@ UniValue ValueFromAmountDecimals(const CAmount& amount, const bool f8Decimals)
 
 CAmount AmountFromValue(const UniValue& value)
 {
-    return AmountFromValueDecimals(value, true);
+    return AmountFromValueDecimals(value, f8DecimalsGlobal);
 }
 
 UniValue ValueFromAmount(const CAmount& amount)
 {
-    return ValueFromAmountDecimals(amount, true);
+    return ValueFromAmountDecimals(amount, f8DecimalsGlobal);
 }
 
 uint256 ParseHashV(const UniValue& v, string strName)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -117,26 +117,42 @@ void RPCTypeCheckObj(const UniValue& o,
     }
 }
 
-CAmount AmountFromValue(const UniValue& value)
+CAmount AmountFromValueDecimals(const UniValue& value, const bool f8Decimals)
 {
     if (!value.isNum() && !value.isStr())
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number or string");
     CAmount amount;
-    if (!ParseFixedPoint(value.getValStr(), 8, &amount))
+    // TODO Decimals: Just don't call ParseFixedPoint if !f8Decimals
+    int decimals = f8Decimals ? 8 : 0;
+    if (!ParseFixedPoint(value.getValStr(), decimals, &amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
     if (!MoneyRange(amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount out of range");
     return amount;
 }
 
-UniValue ValueFromAmount(const CAmount& amount)
+UniValue ValueFromAmountDecimals(const CAmount& amount, const bool f8Decimals)
 {
     bool sign = amount < 0;
+    if (!f8Decimals) {
+        assert(!sign); // FIX throw exception ?
+        return UniValue(UniValue::VNUM, strprintf("%d", amount));
+    }
     int64_t n_abs = (sign ? -amount : amount);
     int64_t quotient = n_abs / COIN;
     int64_t remainder = n_abs % COIN;
     return UniValue(UniValue::VNUM,
             strprintf("%s%d.%08d", sign ? "-" : "", quotient, remainder));
+}
+
+CAmount AmountFromValue(const UniValue& value)
+{
+    return AmountFromValueDecimals(value, true);
+}
+
+UniValue ValueFromAmount(const CAmount& amount)
+{
+    return ValueFromAmountDecimals(amount, true);
 }
 
 uint256 ParseHashV(const UniValue& v, string strName)

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -181,8 +181,10 @@ extern std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strNa
 extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
 
 extern int64_t nWalletUnlockTime;
-extern CAmount AmountFromValue(const UniValue& value);
-extern UniValue ValueFromAmount(const CAmount& amount);
+CAmount AmountFromValueDecimals(const UniValue& value, const bool f8Decimals);
+UniValue ValueFromAmountDecimals(const CAmount& amount, const bool f8Decimals);
+CAmount AmountFromValue(const UniValue& value);
+UniValue ValueFromAmount(const CAmount& amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HelpRequiringPassphrase();
 extern std::string HelpExampleCli(const std::string& methodname, const std::string& args);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -198,6 +198,8 @@ BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
     BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("2099999999999999"), false), 2099999999999999LL);
     BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("2099999999999990"), false), 2099999999999990LL);
     BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("209999999999999"), false), 209999999999999LL);
+    // FIX Decimals: This shouldn't fail? or make sure it always fails
+    // BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("10000000000000000"), false), 10000000000000000LL); // 100 M CURRENCY_UNIT (100 000 000 0000 0000 MINIMAL_UNIT)
 
     BOOST_CHECK_THROW(AmountFromValue(ValueFromString("-0.00000001")), UniValue);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0")), 0LL);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -144,37 +144,37 @@ BOOST_AUTO_TEST_CASE(rpc_format_monetary_values)
     BOOST_CHECK(ValueFromAmountDecimals(2099999999999990LL, false).write() == "2099999999999990");
     BOOST_CHECK(ValueFromAmountDecimals(2099999999999999LL, false).write() == "2099999999999999");
 
-    BOOST_CHECK(ValueFromAmount(0LL).write() == "0.00000000");
-    BOOST_CHECK(ValueFromAmount(1LL).write() == "0.00000001");
-    BOOST_CHECK(ValueFromAmount(17622195LL).write() == "0.17622195");
-    BOOST_CHECK(ValueFromAmount(50000000LL).write() == "0.50000000");
-    BOOST_CHECK(ValueFromAmount(89898989LL).write() == "0.89898989");
-    BOOST_CHECK(ValueFromAmount(100000000LL).write() == "1.00000000");
-    BOOST_CHECK(ValueFromAmount(2099999999999990LL).write() == "20999999.99999990");
-    BOOST_CHECK(ValueFromAmount(2099999999999999LL).write() == "20999999.99999999");
+    BOOST_CHECK(ValueFromAmountDecimals(0LL, true).write() == "0.00000000");
+    BOOST_CHECK(ValueFromAmountDecimals(1LL, true).write() == "0.00000001");
+    BOOST_CHECK(ValueFromAmountDecimals(17622195LL, true).write() == "0.17622195");
+    BOOST_CHECK(ValueFromAmountDecimals(50000000LL, true).write() == "0.50000000");
+    BOOST_CHECK(ValueFromAmountDecimals(89898989LL, true).write() == "0.89898989");
+    BOOST_CHECK(ValueFromAmountDecimals(100000000LL, true).write() == "1.00000000");
+    BOOST_CHECK(ValueFromAmountDecimals(2099999999999990LL, true).write() == "20999999.99999990");
+    BOOST_CHECK(ValueFromAmountDecimals(2099999999999999LL, true).write() == "20999999.99999999");
 
-    BOOST_CHECK_EQUAL(ValueFromAmount(0).write(), "0.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount((COIN/10000)*123456789).write(), "12345.67890000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(-COIN).write(), "-1.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(-COIN/10).write(), "-0.10000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(0, true).write(), "0.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals((COIN/10000)*123456789, true).write(), "12345.67890000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(-COIN, true).write(), "-1.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(-COIN/10, true).write(), "-0.10000000");
 
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*100000000).write(), "100000000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*10000000).write(), "10000000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*1000000).write(), "1000000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*100000).write(), "100000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*10000).write(), "10000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*1000).write(), "1000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*100).write(), "100.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*10).write(), "10.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN).write(), "1.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/10).write(), "0.10000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/100).write(), "0.01000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/1000).write(), "0.00100000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/10000).write(), "0.00010000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/100000).write(), "0.00001000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/1000000).write(), "0.00000100");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/10000000).write(), "0.00000010");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/100000000).write(), "0.00000001");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN*100000000, true).write(), "100000000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN*10000000, true).write(), "10000000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN*1000000, true).write(), "1000000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN*100000, true).write(), "100000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN*10000, true).write(), "10000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN*1000, true).write(), "1000.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN*100, true).write(), "100.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN*10, true).write(), "10.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN, true).write(), "1.00000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN/10, true).write(), "0.10000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN/100, true).write(), "0.01000000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN/1000, true).write(), "0.00100000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN/10000, true).write(), "0.00010000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN/100000, true).write(), "0.00001000");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN/1000000, true).write(), "0.00000100");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN/10000000, true).write(), "0.00000010");
+    BOOST_CHECK_EQUAL(ValueFromAmountDecimals(COIN/100000000, true).write(), "0.00000001");
 }
 
 static UniValue ValueFromString(const std::string &str)
@@ -201,35 +201,35 @@ BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
     // FIX Decimals: This shouldn't fail? or make sure it always fails
     // BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("10000000000000000"), false), 10000000000000000LL); // 100 M CURRENCY_UNIT (100 000 000 0000 0000 MINIMAL_UNIT)
 
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("-0.00000001")), UniValue);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0")), 0LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000000")), 0LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000001")), 1LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.17622195")), 17622195LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.5")), 50000000LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.50000000")), 50000000LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.89898989")), 89898989LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("1.00000000")), 100000000LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.9999999")), 2099999999999990LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.99999999")), 2099999999999999LL);
+    BOOST_CHECK_THROW(AmountFromValueDecimals(ValueFromString("-0.00000001"), true), UniValue);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0"), true), 0LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.00000000"), true), 0LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.00000001"), true), 1LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.17622195"), true), 17622195LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.5"), true), 50000000LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.50000000"), true), 50000000LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.89898989"), true), 89898989LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("1.00000000"), true), 100000000LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("20999999.9999999"), true), 2099999999999990LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("20999999.99999999"), true), 2099999999999999LL);
 
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("1e-8")), COIN/100000000);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.1e-7")), COIN/100000000);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.01e-6")), COIN/100000000);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.0000000000000000000000000000000000000000000000000000000000000000000000000001e+68")), COIN/100000000);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("10000000000000000000000000000000000000000000000000000000000000000e-64")), COIN);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000e64")), COIN);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("1e-8"), true), COIN/100000000);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.1e-7"), true), COIN/100000000);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.01e-6"), true), COIN/100000000);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.0000000000000000000000000000000000000000000000000000000000000000000000000001e+68"), true), COIN/100000000);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("10000000000000000000000000000000000000000000000000000000000000000e-64"), true), COIN);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000e64"), true), COIN);
 
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("1e-9")), UniValue); //should fail
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("0.000000019")), UniValue); //should fail
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000001000000")), 1LL); //should pass, cut trailing 0
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("19e-9")), UniValue); //should fail
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.19e-6")), 19); //should pass, leading 0 is present
+    BOOST_CHECK_THROW(AmountFromValueDecimals(ValueFromString("1e-9"), true), UniValue); //should fail
+    BOOST_CHECK_THROW(AmountFromValueDecimals(ValueFromString("0.000000019"), true), UniValue); //should fail
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.00000001000000"), true), 1LL); //should pass, cut trailing 0
+    BOOST_CHECK_THROW(AmountFromValueDecimals(ValueFromString("19e-9"), true), UniValue); //should fail
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0.19e-6"), true), 19); //should pass, leading 0 is present
 
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("92233720368.54775808")), UniValue); //overflow error
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("1e+11")), UniValue); //overflow error
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("1e11")), UniValue); //overflow error signless
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("93e+9")), UniValue); //overflow error
+    BOOST_CHECK_THROW(AmountFromValueDecimals(ValueFromString("92233720368.54775808"), true), UniValue); //overflow error
+    BOOST_CHECK_THROW(AmountFromValueDecimals(ValueFromString("1e+11"), true), UniValue); //overflow error
+    BOOST_CHECK_THROW(AmountFromValueDecimals(ValueFromString("1e11"), true), UniValue); //overflow error signless
+    BOOST_CHECK_THROW(AmountFromValueDecimals(ValueFromString("93e+9"), true), UniValue); //overflow error
 }
 
 BOOST_AUTO_TEST_CASE(json_parse_errors)
@@ -240,8 +240,8 @@ BOOST_AUTO_TEST_CASE(json_parse_errors)
     BOOST_CHECK_EQUAL(ParseNonRFCJSONValue(" 1.0").get_real(), 1.0);
     BOOST_CHECK_EQUAL(ParseNonRFCJSONValue("1.0 ").get_real(), 1.0);
 
-    BOOST_CHECK_THROW(AmountFromValue(ParseNonRFCJSONValue(".19e-6")), std::runtime_error); //should fail, missing leading 0, therefore invalid JSON
-    BOOST_CHECK_EQUAL(AmountFromValue(ParseNonRFCJSONValue("0.00000000000000000000000000000000000001e+30 ")), 1);
+    BOOST_CHECK_THROW(AmountFromValueDecimals(ParseNonRFCJSONValue(".19e-6"), true), std::runtime_error); //should fail, missing leading 0, therefore invalid JSON
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ParseNonRFCJSONValue("0.00000000000000000000000000000000000001e+30 "), true), 1);
     // Invalid, initial garbage
     BOOST_CHECK_THROW(ParseNonRFCJSONValue("[1.0"), std::runtime_error);
     BOOST_CHECK_THROW(ParseNonRFCJSONValue("a1.0"), std::runtime_error);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -132,6 +132,18 @@ BOOST_AUTO_TEST_CASE(rpc_createraw_op_return)
 
 BOOST_AUTO_TEST_CASE(rpc_format_monetary_values)
 {
+    BOOST_CHECK(ValueFromAmountDecimals(0LL, false).write() == "0");
+    BOOST_CHECK(ValueFromAmountDecimals(1LL, false).write() == "1");
+    BOOST_CHECK(ValueFromAmountDecimals(17622195LL, false).write() == "17622195");
+    BOOST_CHECK(ValueFromAmountDecimals(50000000LL, false).write() == "50000000");
+    BOOST_CHECK(ValueFromAmountDecimals(89898989LL, false).write() == "89898989");
+    BOOST_CHECK(ValueFromAmountDecimals(100000000LL, false).write() == "100000000"); // 1 CURRENCY_UNIT
+    BOOST_CHECK(ValueFromAmountDecimals(100000000000000LL, false).write() == "100000000000000"); // 1 M CURRENCY_UNIT
+    BOOST_CHECK(ValueFromAmountDecimals(2100000000000000LL, false).write() == "2100000000000000"); // 21 M CURRENCY_UNIT
+    BOOST_CHECK(ValueFromAmountDecimals(10000000000000000LL, false).write() == "10000000000000000");  // 100 M CURRENCY_UNIT (100 000 000 0000 0000 MINIMAL_UNIT)
+    BOOST_CHECK(ValueFromAmountDecimals(2099999999999990LL, false).write() == "2099999999999990");
+    BOOST_CHECK(ValueFromAmountDecimals(2099999999999999LL, false).write() == "2099999999999999");
+
     BOOST_CHECK(ValueFromAmount(0LL).write() == "0.00000000");
     BOOST_CHECK(ValueFromAmount(1LL).write() == "0.00000001");
     BOOST_CHECK(ValueFromAmount(17622195LL).write() == "0.17622195");
@@ -174,6 +186,19 @@ static UniValue ValueFromString(const std::string &str)
 
 BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
 {
+    BOOST_CHECK_THROW(AmountFromValueDecimals(ValueFromString("-1"), false), UniValue);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("0"), false), 0LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("1"), false), 1LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("17622195"), false), 17622195LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("50000000"), false), 50000000LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("89898989"), false), 89898989LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("100000000"), false),  100000000LL); // 1 CURRENCY_UNIT
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("100000000000000"), false), 100000000000000LL); // 1 M CURRENCY_UNIT
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("2100000000000000"), false), 2100000000000000LL); // 21 M CURRENCY_UNIT
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("2099999999999999"), false), 2099999999999999LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("2099999999999990"), false), 2099999999999990LL);
+    BOOST_CHECK_EQUAL(AmountFromValueDecimals(ValueFromString("209999999999999"), false), 209999999999999LL);
+
     BOOST_CHECK_THROW(AmountFromValue(ValueFromString("-0.00000001")), UniValue);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0")), 0LL);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000000")), 0LL);

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -437,7 +437,7 @@ public:
             for (unsigned i = 0; i < scriptWitness.stack.size(); i++) {
                 wit.push_back(HexStr(scriptWitness.stack[i]));
             }
-            wit.push_back(ValueFromAmount(nValue));
+            wit.push_back(ValueFromAmountDecimals(nValue, true));
             array.push_back(wit);
         }
         array.push_back(FormatScript(spendTx.vin[0].scriptSig));
@@ -876,7 +876,7 @@ BOOST_AUTO_TEST_CASE(script_json_test)
             for (i = 0; i < test[pos].size()-1; i++) {
                 witness.stack.push_back(ParseHex(test[pos][i].get_str()));
             }
-            nValue = AmountFromValue(test[pos][i]);
+            nValue = AmountFromValueDecimals(test[pos][i], true);
             pos++;
         }
         if (test.size() < 4 + pos) // Allow size > 3; extra stuff ignored (useful for comments)

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -612,6 +612,7 @@ static inline bool ProcessMantissaDigit(char ch, int64_t &mantissa, int &mantiss
 
 bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out)
 {
+    assert(decimals == 8 || decimals == 0);
     int64_t mantissa = 0;
     int64_t exponent = 0;
     int mantissa_tzeros = 0;


### PR DESCRIPTION
The only reason upstream maintains 8 decimals is not to break the API, but there's users that prefer satoshis, see https://github.com/bitcoin/bitcoin/pull/9882 (previously https://github.com/bitcoin/bitcoin/pull/9855 and https://github.com/bitcoin/bitcoin/pull/3759).

An orientiation on how disruptive this is for python tests if we change the default for -rpcamountdecimals to false as in the last commit:
```
TEST                           | PASSED | DURATION

wallet.py                      | False  | 5 s
bip68-112-113-p2p.py           | False  | 7 s
wallet-hd.py                   | False  | 4 s
listtransactions.py            | False  | 4 s
receivedby.py                  | False  | 4 s
walletbackup.py                | False  | 14 s
mempool_resurrect_test.py      | False  | 3 s
txn_doublespend.py --mineblock | False  | 4 s
txn_clone.py                   | False  | 4 s
getchaintips.py                | False  | 4 s
mempool_spendcoinbase.py       | False  | 3 s
rawtransactions.py             | False  | 7 s
rest.py                        | False  | 7 s
mempool_reorg.py               | False  | 4 s
mempool_limit.py               | False  | 4 s
httpbasics.py                  | True   | 4 s
multi_rpc.py                   | True   | 3 s
proxy_test.py                  | True   | 4 s
zapwallettxes.py               | False  | 7 s
merkle_blocks.py               | False  | 6 s
signrawtransactions.py         | False  | 3 s
fundrawtransaction.py          | False  | 7 s
decodescript.py                | True   | 3 s
blockchain.py                  | False  | 3 s
nodehandling.py                | True   | 14 s
disablewallet.py               | True   | 3 s
reindex.py                     | True   | 13 s
keypool.py                     | True   | 5 s
prioritise_transaction.py      | False  | 7 s
invalidblockrequest.py         | True   | 4 s
invalidtxrequest.py            | True   | 4 s
abandonconflict.py             | False  | 4 s
p2p-versionbits-warning.py     | True   | 9 s
p2p-segwit.py                  | False  | 10 s
segwit.py                      | False  | 2 s
signmessages.py                | True   | 3 s
importprunedfunds.py           | False  | 4 s
sendheaders.py                 | True   | 29 s
zmq_test.py                    | False  | 4 s
p2p-fullblocktest.py           | True   | 223 s

ALL                            | False  | 456 s (accumulated)
```