### PR TITLE
RPC: getblockstats: Use vsize for feerate_old and introduce total_size_old stat

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -8,6 +8,8 @@
 #include "hash.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
+#include "consensus/consensus.h"
+#include "consensus/validation.h"
 
 std::string COutPoint::ToString() const
 {
@@ -94,6 +96,11 @@ CAmount CTransaction::GetValueOut() const
 unsigned int CTransaction::GetTotalSize() const
 {
     return ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
+}
+
+unsigned int CTransaction::GetVirtualTotalSize() const
+{
+    return (GetTransactionWeight(*this) + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR;
 }
 
 std::string CTransaction::ToString() const

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -330,6 +330,12 @@ public:
      */
     unsigned int GetTotalSize() const;
 
+    /**
+     * Get the transaction's total virtual transaction size in bytes, as seen by nodes pre BIP 141/144. 
+     * @return Total virtual transaction size in bytes
+     */
+    unsigned int GetVirtualTotalSize() const;
+
     bool IsCoinBase() const
     {
         return (vin.size() == 1 && vin[0].prevout.IsNull());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1748,7 +1748,6 @@ UniValue getblockstats(const JSONRPCRequest& request)
         "medianfeerate_old",
         "avgfeerate_old",
     };
-
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 4)
         throw std::runtime_error(
             "getblockstats ( nStart nEnd stats )\n"

--- a/test/functional/getblockstats.py
+++ b/test/functional/getblockstats.py
@@ -57,6 +57,7 @@ class GetblockstatsTest(BitcoinTestFramework):
             "utxo_increase",
             "utxo_size_inc",
             "total_size",
+            "total_vsize",
             "total_weight",
             "swtotal_size",
             "swtotal_weight",
@@ -69,7 +70,6 @@ class GetblockstatsTest(BitcoinTestFramework):
             "maxfeerate",
             "medianfeerate",
             "avgfeerate",
-            "total_size_old",
             "minfeerate_old",
             "maxfeerate_old",
             "medianfeerate_old",
@@ -90,6 +90,7 @@ class GetblockstatsTest(BitcoinTestFramework):
         assert_equal(stats['utxo_increase'][0], 2)
         assert_equal(stats['utxo_size_inc'][0], 173)
         assert_equal(stats['total_size'][0], 0)
+        assert_equal(stats['total_vsize'][0], 0)
         assert_equal(stats['total_weight'][0], 0)
         assert_equal(stats['swtotal_size'][0], 0)
         assert_equal(stats['swtotal_weight'][0], 0)
@@ -102,7 +103,6 @@ class GetblockstatsTest(BitcoinTestFramework):
         assert_equal(stats['maxfeerate'][0], 0)
         assert_equal(stats['medianfeerate'][0], 0)
         assert_equal(stats['avgfeerate'][0], 0)
-        assert_equal(stats['total_size_old'][0], 0)
         assert_equal(stats['minfeerate_old'][0], 0)
         assert_equal(stats['maxfeerate_old'][0], 0)
         assert_equal(stats['medianfeerate_old'][0], 0)

--- a/test/functional/getblockstats.py
+++ b/test/functional/getblockstats.py
@@ -69,6 +69,7 @@ class GetblockstatsTest(BitcoinTestFramework):
             "maxfeerate",
             "medianfeerate",
             "avgfeerate",
+            "total_size_old",
             "minfeerate_old",
             "maxfeerate_old",
             "medianfeerate_old",
@@ -101,6 +102,7 @@ class GetblockstatsTest(BitcoinTestFramework):
         assert_equal(stats['maxfeerate'][0], 0)
         assert_equal(stats['medianfeerate'][0], 0)
         assert_equal(stats['avgfeerate'][0], 0)
+        assert_equal(stats['total_size_old'][0], 0)
         assert_equal(stats['minfeerate_old'][0], 0)
         assert_equal(stats['maxfeerate_old'][0], 0)
         assert_equal(stats['medianfeerate_old'][0], 0)


### PR DESCRIPTION
This fixes [sipa's comment](https://github.com/bitcoin/bitcoin/pull/10757#pullrequestreview-60305113) about using vsize when calculating feerate_old.

I also introduced a new statistic: total_size_old. This is the block size as seen by pre segwit nodes.